### PR TITLE
fix out-of-bound access for chord lookup in online editor

### DIFF
--- a/Resources/Online-Editor/editor.js
+++ b/Resources/Online-Editor/editor.js
@@ -634,7 +634,7 @@ class ScofoOnlineEditor {
                 // process chord not tied
                 if (nextNote !== undefined && nextNote.isChord && !note.isTied) {
                     type = "CHORD";
-                    while (true) {
+                    while (i < allNotes.length - 1) {
                         i++;
                         nextNote = allNotes[i];
                         if (nextNote.isChord) {


### PR DESCRIPTION
if the last notes are in a chord, `nextnote.isChord` will always be `true` and increment `i` to out-of-bound, which update `nextnote` to be `undefined` and cause a error to stop the score from rendering. I just add a simple bounding check to fix it.